### PR TITLE
Fix broken attributes and code labels

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,7 @@
 name: imdg
 title: Hazelcast IMDG
 version: latest-dev
+display_version: '4.2-SNAPSHOT'
 asciidoc:
   attributes:
     javasource: ROOT:example$

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -97,7 +97,7 @@ public class MapSample {
 C++::
 +
 --
-[source,c++]
+[source,cpp]
 ----
 //Installation notes: Download the latest C++ library from
 //https://hazelcast.org/imdg/clients-languages/cplusplus/
@@ -127,7 +127,7 @@ int main() {
 C#::
 +
 --
-[source,java]
+[source,cs]
 ----
 //Installation notes: Run the following command at the NuGet package manager console
 //Install-Package Hazelcast.Net -Pre

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -124,7 +124,7 @@ int main() {
 ----
 --
 
-C#::
+C Sharp::
 +
 --
 [source,cs]

--- a/docs/modules/ROOT/pages/starting-members-clients.adoc
+++ b/docs/modules/ROOT/pages/starting-members-clients.adoc
@@ -70,7 +70,7 @@ hazelcast::client::HazelcastClient hzclient(config);
 ----
 --
 
-C#::
+C Sharp::
 +
 --
 [source,cs]

--- a/docs/modules/ROOT/pages/starting-members-clients.adoc
+++ b/docs/modules/ROOT/pages/starting-members-clients.adoc
@@ -63,7 +63,7 @@ HazelcastInstance hzclient = HazelcastClient.newHazelcastClient();
 C++::
 +
 --
-[source,c++]
+[source,cpp]
 ----
 hazelcast::client::ClientConfig config;
 hazelcast::client::HazelcastClient hzclient(config);
@@ -73,7 +73,7 @@ hazelcast::client::HazelcastClient hzclient(config);
 C#::
 +
 --
-[source,c++]
+[source,cs]
 ----
 var cfg = new ClientConfig();
 var hzclient = HazelcastClient.NewHazelcastClient(cfg);

--- a/docs/modules/installation/pages/installing-using-maven.adoc
+++ b/docs/modules/installation/pages/installing-using-maven.adoc
@@ -18,7 +18,7 @@ Hazelcast Open Source Edition::
 + 
 -- 
 
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <dependencies>
     <dependency>
@@ -32,7 +32,7 @@ Hazelcast Open Source Edition::
 
 Hazelcast Enterprise Edition::
 +
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <!-- You need to define following repository: -->
 <repository>


### PR DESCRIPTION
- Added `subs="attributes+"` to code blocks that reference attributes to allow Antora to replace them
- Fixed code sample labels for c++ and c# that were causing the wrong samples to be displayed