### PR TITLE
Fix code labels

### DIFF
--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -124,7 +124,7 @@ int main() {
 ----
 --
 
-C#::
+C Sharp::
 +
 --
 [source,cs]

--- a/docs/modules/ROOT/pages/starting-members-clients.adoc
+++ b/docs/modules/ROOT/pages/starting-members-clients.adoc
@@ -70,7 +70,7 @@ hazelcast::client::HazelcastClient hzclient(config);
 ----
 --
 
-C#::
+C Sharp::
 +
 --
 [source,cs]


### PR DESCRIPTION
The ID of each tab in HTML includes the label of that tab in Asciidoc. So, C++ and C# resulted in the same id (+ and # symbols are not used).

- Renamed the C# label to C Sharp