### PR TITLE
Add an external link checker

### DIFF
--- a/.brok-ignore-links
+++ b/.brok-ignore-links
@@ -1,0 +1,4 @@
+http://127.0.0.1
+http://member_ip:port/
+http://localhost
+https://com.example.com

--- a/.brok-ignore-links
+++ b/.brok-ignore-links
@@ -2,3 +2,6 @@ http://127.0.0.1
 http://member_ip:port/
 http://localhost
 https://com.example.com
+http://www.hazelcast.com/version.jsp.
+http://versioncheck.hazelcast.com/version.jsp.
+http://phonehome.hazelcast.com/ping.

--- a/.brok-ignore-links
+++ b/.brok-ignore-links
@@ -2,6 +2,8 @@ http://127.0.0.1
 http://member_ip:port/
 http://localhost
 https://com.example.com
-http://www.hazelcast.com/version.jsp.
-http://versioncheck.hazelcast.com/version.jsp.
-http://phonehome.hazelcast.com/ping.
+http://www.hazelcast.com/version.jsp
+http://versioncheck.hazelcast.com/version.jsp
+http://phonehome.hazelcast.com/ping
+https://hazelcast.com
+https://hazelcast.org

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,4 +26,4 @@ jobs:
         sudo apt-get update && sudo apt-get install wget libtinfo5 -y
         wget https://github.com/smallhadroncollider/brok/releases/download/1.1.0/brok-1.1.0_x86-64-linux.deb
         sudo dpkg -i brok-1.1.0_x86-64-linux.deb
-        brok --only-failures --interval 1000 --ignore $(cat .brok-ignore-links) $(find . -type f -name "*.adoc")
+        brok --only-failures --interval 500 --ignore $(cat .brok-ignore-links) $(find . -type f -name "*.adoc")

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,4 +26,4 @@ jobs:
         sudo apt-get update && sudo apt-get install wget libtinfo5 -y
         wget https://github.com/smallhadroncollider/brok/releases/download/1.1.0/brok-1.1.0_x86-64-linux.deb
         sudo dpkg -i brok-1.1.0_x86-64-linux.deb
-        brok --only-failures --interval 500 --ignore $(cat .brok-ignore-links) $(find . -type f -name "*.adoc")
+        brok --only-failures --interval 1000 --ignore $(cat .brok-ignore-links) $(find . -type f -name "*.adoc")

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,4 +26,4 @@ jobs:
         sudo apt-get update && sudo apt-get install wget libtinfo5 -y
         wget https://github.com/smallhadroncollider/brok/releases/download/1.1.0/brok-1.1.0_x86-64-linux.deb
         sudo dpkg -i brok-1.1.0_x86-64-linux.deb
-        brok --ignore $(cat .brok-ignore-links) $(find . -type f -name "*.adoc")
+        brok --only-failures --interval 500 --ignore $(cat .brok-ignore-links) $(find . -type f -name "*.adoc")

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,13 +1,14 @@
 # This workflow will check if the incoming pull request builds a valid documentation site
 
-name: Validate site
+name: Check for dead links
 
 on:
   pull_request:
     branches: [master, v*, archive]
+  workflow_dispatch:
 
 jobs:
-  build:
+  check-links:
 
     runs-on: ubuntu-latest
 
@@ -16,6 +17,13 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 10
-    - run: |
+    - name: Check for broken internal links
+      run: |
         npm i
         npm run-script check-links-local
+    - name: Check for broken external links
+      run: |
+        sudo apt-get update && sudo apt-get install wget libtinfo5 -y
+        wget https://github.com/smallhadroncollider/brok/releases/download/1.1.0/brok-1.1.0_x86-64-linux.deb
+        sudo dpkg -i brok-1.1.0_x86-64-linux.deb
+        brok --ignore $(cat .brok-ignore-links) $(find . -type f -name "*.adoc")

--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -458,12 +458,12 @@ the xref:ROOT:system-properties.adoc[System Properties appendix].
 **Client disconnections during idle time?**
 
 In Hazelcast, socket connections are created with the `SO_KEEPALIVE` option enabled by default.
-In most operating systems, default keep-alive time is 2 hours.
+In most operating systems, the default keep-alive time is 2 hours.
 If you have a firewall between clients and servers which is configured to reset idle connections/sessions,
 make sure that the firewall's idle timeout is greater than the TCP keep-alive defined in the OS.
 
 See http://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html[Using TCP keepalive under Linux^] and
-http://technet.microsoft.com/en-us/library/cc957549.aspx[Microsoft TechNet^] for additional information.
+https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc957549%28v%3Dtechnet.10%29[Microsoft Windows^] for additional information.
 
 '''
 **OOME: Unable to create new native thread?**

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -74,8 +74,6 @@ See the following resources:
 
 * https://hazelcast.atlassian.net/wiki/display/COM/Developing%2Bwith%2BGit[Developing with Git^]:
 Document that explains the branch mechanism of Hazelcast and how to request changes.
-* https://hazelcast.atlassian.net/wiki/display/COM/Hazelcast%2BContributor+Agreement[Hazelcast Contributor Agreement form^]: Form that each contributing developer needs to fill and send back
-to Hazelcast.
 * https://github.com/hazelcast/hazelcast[Hazelcast on GitHub^]: Hazelcast repository where the
 code is developed, issues and pull requests are managed.
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -72,10 +72,9 @@ features, enhancements and fixes performed for each Hazelcast IMDG release.
 You can contribute to the Hazelcast IMDG code, report a bug, or request an enhancement.
 See the following resources:
 
-* https://hazelcast.atlassian.net/wiki/display/COM/Developing+with+Git[Developing with Git^]:
+* https://hazelcast.atlassian.net/wiki/display/COM/Developing%2Bwith%2BGit[Developing with Git^]:
 Document that explains the branch mechanism of Hazelcast and how to request changes.
-* https://hazelcast.atlassian.net/wiki/display/COM/Hazelcast+Contributor+Agreement[Hazelcast
-Contributor Agreement form^]: Form that each contributing developer needs to fill and send back
+* https://hazelcast.atlassian.net/wiki/display/COM/Hazelcast%2BContributor+Agreement[Hazelcast Contributor Agreement form^]: Form that each contributing developer needs to fill and send back
 to Hazelcast.
 * https://github.com/hazelcast/hazelcast[Hazelcast on GitHub^]: Hazelcast repository where the
 code is developed, issues and pull requests are managed.

--- a/docs/modules/clients/pages/dotnet.adoc
+++ b/docs/modules/clients/pages/dotnet.adoc
@@ -7,5 +7,5 @@ The API is very similar to the Java native client.
 
 See Hazelcast .NET client's own GitHub https://github.com/hazelcast/hazelcast-csharp-client[repo^]
 for information on configuring and starting the client.
-You can also find https://github.com/hazelcast/hazelcast-csharp-client/tree/master/Hazelcast.Examples[code samples^]
+You can also find https://github.com/hazelcast/hazelcast-csharp-client/tree/master/src/Hazelcast.Net.Examples[code samples^]
 for this client in this repo.

--- a/docs/modules/clusters/pages/network-configuration.adoc
+++ b/docs/modules/clusters/pages/network-configuration.adoc
@@ -367,7 +367,7 @@ Its default value is 224.2.2.3.
 * `multicast-port`: The multicast socket port that the Hazelcast member listens to and
 sends discovery messages through. Its default value is 54327.
 * `multicast-time-to-live`: Time-to-live value for multicast packets sent out to control
-the scope of multicasts. See more information http://www.tldp.org/HOWTO/Multicast-HOWTO-2.html[here].
+the scope of multicasts. See more information, see http://www.tldp.org/HOWTO/Multicast-HOWTO-2.html[The Linux Documentation Project^].
 * `multicast-timeout-seconds`: Only when the members are starting up, this timeout (in seconds)
 specifies the period during which a member waits for a multicast response from another member.
 For example, if you set it as 60 seconds, each member waits for 60 seconds until a leader

--- a/docs/modules/computing/pages/entry-processor.adoc
+++ b/docs/modules/computing/pages/entry-processor.adoc
@@ -8,7 +8,7 @@ If you are doing the process described above, you should consider using entry pr
 
 NOTE: Entry processor is meant to process a single entry per call. Processing multiple entries and data structures in an entry processor is not supported as it may result in deadlocks.
 
-NOTE: Note that Hazelcast Jet is a good fit when you want to perform processing that involves multiple entries (aggregations, joins, etc.), or involves multiple computing steps to be made parallel. Hazelcast Jet contains an Entry Processor Sink to allow you to update Hazelcast IMDG data as a result of your Hazelcast Jet computation. See the https://docs.hazelcast.org/docs/jet/latest/manual/index.html#connector-imdg[Hazelcast Jet Reference Manual^].
+NOTE: Note that Hazelcast Jet is a good fit when you want to perform processing that involves multiple entries (aggregations, joins, etc.), or involves multiple computing steps to be made parallel. Hazelcast Jet contains an Entry Processor Sink to allow you to update Hazelcast IMDG data as a result of your Hazelcast Jet computation. See the https://jet-start.sh/[Hazelcast Jet documentation^].
 
 == Performing Fast In-Memory Map Operations
 

--- a/docs/modules/computing/pages/executor-service.adoc
+++ b/docs/modules/computing/pages/executor-service.adoc
@@ -7,7 +7,8 @@ The default implementation of this framework (`ThreadPoolExecutor`) is designed 
 
 
 '''
-NOTE: Note that you may want to use https://jet.hazelcast.org/[Hazelcast Jet^] if you want to process batch or real-time streaming data. See the https://jet.hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing^] and https://jet.hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing^] use cases for Hazelcast Jet.
+NOTE: Note that you may want to use https://jet.hazelcast.org/[Hazelcast Jet^] if you want to process batch or real-time streaming data. See the https://hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing^]
+and https://hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing^] use cases for Hazelcast Jet.
 
 With `IExecutorService`, you can execute tasks asynchronously and perform other useful tasks. If your task execution takes longer than expected, you can cancel the task execution. Tasks should be `Serializable` since they are distributed.
 

--- a/docs/modules/cp-subsystem/pages/cp-subsystem.adoc
+++ b/docs/modules/cp-subsystem/pages/cp-subsystem.adoc
@@ -13,8 +13,8 @@ consistent layer for a set of distributed data structures. Its APIs can be used
 for implementing distributed coordination use cases, such as leader election,
 distributed locking, synchronization, and metadata management. It is accessed
 via `HazelcastInstance.getCPSubsystem()`. Its data structures are _CP_ with
-respect to the http://awoc.wolski.fi/dlib/big-data/Brewer_podc_keynote_2000.pdf[_CAP_ principle],
-i.e., they always maintain https://aphyr.com/posts/313-strong-consistency-models[linearizability]
+respect to the http://awoc.wolski.fi/dlib/big-data/Brewer_podc_keynote_2000.pdf[_CAP_ principle^],
+i.e., they always maintain https://aphyr.com/posts/313-strong-consistency-models[linearizability^]
 and prefer consistency over availability during network partitions. Besides
 network partitions, CP Subsystem withstands server and client failures.
 
@@ -28,7 +28,7 @@ These members are called _CP members_ and they can also contain data for
 the other regular _AP_ Hazelcast data structures, such as `IMap`, `ISet`.
 
 Data structures in CP Subsystem run in _CP groups_. Each CP group elects its
-own Raft leader and runs the https://raft.github.io/[Raft consensus algorithm]
+own Raft leader and runs the https://raft.github.io/[Raft consensus algorithm^]
 independently. CP Subsystem runs 2 CP groups by default:
 
 * The first one is _the METADATA CP group_ which is an internal CP group

--- a/docs/modules/data-structures/pages/list.adoc
+++ b/docs/modules/data-structures/pages/list.adoc
@@ -17,8 +17,8 @@ https://jet.hazelcast.org/[Hazelcast Jet^], IList can also be used by it for uni
 testing or similar non-production situations. See https://docs.hazelcast.org/docs/jet/latest/manual/#imdg-list[here^]
 in the Hazelcast Jet Reference Manual to learn how Jet can use IList, e.g., how it can fill
 IList with data, consume it in a Jet job and drain the results to another IList.
-See also the https://jet.hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing^]
-and https://jet.hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing^]
+See also the https://hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing^]
+and https://hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing^]
 use cases for Hazelcast Jet.
 
 [[getting-a-list-and-putting-items]]

--- a/docs/modules/data-structures/pages/map.adoc
+++ b/docs/modules/data-structures/pages/map.adoc
@@ -10,8 +10,8 @@ known get and put methods.
 NOTE: IMap data structure can also be used by https://jet.hazelcast.org/[Hazelcast Jet^]
 for Real-Time Stream Processing (by enabling the Event Journal on your map) and
 Fast Batch Processing. Hazelcast Jet uses IMap as a source (reads data from IMap) and as a sink
-(writes data to IMap). See the https://jet.hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing^]
-and https://jet.hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing^]
+(writes data to IMap). See the https://hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing^]
+and https://hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing^]
 use cases for Hazelcast Jet. See also https://jet-start.sh/docs/api/sources-sinks#imap[here^]
 in the Hazelcast Jet Programming Guide to learn how Jet uses IMap, i.e., how it can read from and write to IMap.
 

--- a/docs/modules/integrated-clustering/pages/spring.adoc
+++ b/docs/modules/integrated-clustering/pages/spring.adoc
@@ -420,9 +420,6 @@ NOTE: Spring managed properties/fields are marked as `transient`.
 
 == Adding Caching to Spring
 
-**Code Sample**: See the sample application for
-https://github.com/hazelcast/hazelcast-code-samples/tree/master/hazelcast-integration/spring-cache-manager[Spring Cache^].
-
 As of version 3.1, Spring Framework provides support for adding caching
 into an existing Spring application. Spring 3.2 and later versions support
 JCache compliant caching providers. You can also use JCache caching
@@ -603,9 +600,6 @@ See the https://github.com/hazelcast/hazelcast-hibernate#configuring-regionfacto
 in the Hazelcast Hibernate GitHub repository for more information.
 
 == Configuring Hazelcast Transaction Manager
-
-**Code Sample**: See the https://github.com/hazelcast/hazelcast-code-samples/tree/master/hazelcast-integration/spring-transaction-manager[sample application^]
-for Hazelcast Transaction Manager in our code samples repository.
 
 You can get rid of the boilerplate code to begin, commit or rollback
 transactions by using https://docs.hazelcast.org/docs/{page-component-version}/javadoc/com/hazelcast/spring/transaction/HazelcastTransactionManager.html[HazelcastTransactionManager^]

--- a/docs/modules/jcache/pages/icache.adoc
+++ b/docs/modules/jcache/pages/icache.adoc
@@ -16,12 +16,9 @@ NOTE: ICache data structure can also be used by
 https://jet.hazelcast.org/[Hazelcast Jet^] for Real-Time Stream Processing
 (by enabling the Event Journal on your cache) and Fast Batch Processing.
 Hazelcast Jet uses ICache as a source (reads data from ICache) and as a sink
-(writes data to ICache). See the https://jet.hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing^]
-and https://jet.hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing^]
-use cases for Hazelcast Jet. See also
-https://docs.hazelcast.org/docs/jet/latest/manual/index.html#connector-imdg[here^] in the
-Hazelcast Jet Reference Manual to learn how Jet uses ICache, i.e., how it can
-read from and write to ICache.
+(writes data to ICache). See the https://hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing^]
+and https://hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing^]
+use cases for Hazelcast Jet. See also https://jet-start.sh/docs/api/data-structures#icache[how Jet reads from and writes to ICache]^.
 
 == Scoping to Join Clusters
 

--- a/docs/modules/jcache/pages/tck.adoc
+++ b/docs/modules/jcache/pages/tck.adoc
@@ -52,7 +52,7 @@ embedded Hazelcast member.
 
 Complete command line example:
 
-[source,sh]
+[source,shell]
 ----
 git clone https://github.com/jsr107/jsr107tck
 (clones JSR107 TCK repository to local directory jsr107tck)
@@ -69,6 +69,6 @@ mvn -Dimplementation-groupId=com.hazelcast -Dimplementation-artifactId=hazelcast
      clean install
 ----
 
-See also the link:https://docs.google.com/document/d/1m8d1Z44IFGAd20bXEvT2G\--vWXbxaJctk16M2rmbM24/edit?ts=59fdff73[TCK 1.1.0 User Guide^] or link:https://docs.google.com/document/d/1w3Ugj_oEqjMlhpCkGQOZkd9iPf955ZWHAVdZzEwYYdU/edit[TCK 1.0.0 User Guide^]
+See also the link:https://docs.google.com/document/d/1m8d1Z44IFGAd20bXEvT2G--vWXbxaJctk16M2rmbM24/edit?ts=59fdff73[TCK 1.1.0 User Guide^] or link:https://docs.google.com/document/d/1w3Ugj_oEqjMlhpCkGQOZkd9iPf955ZWHAVdZzEwYYdU/edit[TCK 1.0.0 User Guide^]
 for more information on the testing instructions.
 

--- a/docs/modules/plugins/pages/framework-integration.adoc
+++ b/docs/modules/plugins/pages/framework-integration.adoc
@@ -77,7 +77,7 @@ See the following resources for more details:
 
 == Micronaut
 
-Hazelcast can be used as a caching provider in the https://micronaut.io/[Micronaut] framework.
+Hazelcast can be used as a caching provider in the https://micronaut.io/[Micronaut^] framework.
 See the following resources for more details:
 
 * https://micronaut-projects.github.io/micronaut-cache/snapshot/guide/#hazelcast[Micronaut: Hazelcast Support^]


### PR DESCRIPTION
- Added an extra job to check external links, using the [brok tool](https://github.com/smallhadroncollider/brok)
- Added a `.brok-ignore-links` file, which lists any URLs that should not be checked such as `example.com`
- Removed links to the `spring-cache-manager` and `spring-transaction-manager` code samples because these were removed in a [clean-up PR](https://github.com/hazelcast/hazelcast-code-samples/pull/448)