### PR TITLE
Update links to hazelcast repo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,8 +4,8 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 // URLs:
-:url-org: https://github.com/JakeSCahill
-:url-contribute: https://github.com/JakeSCahill/hazelcast-docs/blob/develop/.github/CONTRIBUTING.adoc
+:url-org: https://github.com/hazelcast
+:url-contribute: https://github.com/hazelcast/hazelcast-docs/blob/develop/.github/CONTRIBUTING.adoc
 :url-ui: {url-org}/hazelcast-docs-ui
 :url-playbook: {url-org}/hazelcast-docs
 

--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -8,7 +8,7 @@ content:
     start_path: docs
 ui: 
   bundle:
-    url: https://github.com/JakeSCahill/hazelcast-docs-ui/releases/download/v1.1.13/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.1.13/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -6,6 +6,6 @@ asciidoc:
   attributes:
     javasource: ROOT:example$
     page-toclevels: 1
-    page-ghissue: https://github.com/JakeSCahill/hazelcast-reference-manual/issues/new
+    page-ghissue: https://github.com/hazelcast/hazelcast-reference-manual/issues/new
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
Updated GitHub links so that they don't break when we transfer ownerhip of this repository to the hazelcast organization